### PR TITLE
docs: wire 7 agent profiles into the issue-driven flow (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,3 +191,51 @@ gh pr create --fill                    # uses latest commit message
 gh pr view --web
 gh pr checks
 ```
+
+## Agent ownership
+
+Seven specialized subagents live in `.claude/agents/*.md`. Each has a narrow scope, a tool whitelist, and a required response format. The top-level session **delegates** to them via the `Task` tool.
+
+| Stage of the flow               | Agent          | Trigger                                                         |
+|---------------------------------|----------------|-----------------------------------------------------------------|
+| Understand existing code        | `explorer`     | "how does X work", "trace X", "where is X implemented"          |
+| Design a new subsystem + ADR    | `architect`    | new `app/` package, new external dep, new protocol, new authz   |
+| Take issue #N → branch → PR     | `implementer`  | "implement #N", "take on issue #N"                              |
+| Fix a reported bug              | `bug-hunter`   | bug report with symptom; starts with failing regression test    |
+| Pre-merge review                | `reviewer`     | **proactive** — run before any `gh pr merge`                    |
+| Hooks / workflows / compose     | `ci-devops`    | touching `.github/`, `.pre-commit-config.yaml`, `deploy/`, Dockerfiles |
+| Sync docs with code             | `docs-writer`  | **proactive** — after a PR that changes setup, commands, or conventions |
+
+### Delegate vs handle directly
+
+The main session **delegates** these:
+
+- Any non-trivial read-only investigation (> 3 files or > 5 minutes of grep) → `explorer`
+- Any production code change scoped to a single issue → `implementer`
+- Any bug report with a reproducer → `bug-hunter`
+- Every PR before `gh pr merge` → `reviewer`
+- Any CI / hook / infra change → `ci-devops`
+- Any docs update driven by a code change → `docs-writer` (may run proactively after merges)
+- Any design choice that warrants an ADR → `architect`
+
+The main session **handles directly** (never delegates):
+
+- Clarifying requirements with the user (`AskUserQuestion`).
+- Authorizing destructive actions (`gh pr merge`, `git push --force`, `gh api -X DELETE …`). The user authorizes, the main session executes.
+- Coordinating multi-agent workflows (e.g. architect → implementer → reviewer on a multi-PR epic).
+- Reading and writing `followup.md` between agent handoffs.
+- Escalating when an agent reports a blocker it cannot resolve.
+
+### How to invoke
+
+Explicit:
+```
+Task(subagent_type="implementer", prompt="Take on issue #2: ...")
+Task(subagent_type="reviewer",    prompt="Review PR #N")
+```
+
+Implicit (proactive): the agent's `description` field triggers automatic delegation on matching phrasing — e.g. "please review PR #14" picks `reviewer`, "how does our auth work" picks `explorer`. Keep prompts phrased like the triggers so delegation is deterministic.
+
+### Invariant
+
+Every PR produced by an agent still goes through the three-layer quality gate (pre-commit, pre-push, CI) and branch protection on `main`. Agents don't get a bypass — they just do the work, and the gate checks the output.

--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ npm run build
 
 Committed to `.claude/agents/` — seven specialized Claude Code subagents with narrow scopes, tool whitelists, and required response formats:
 
-| Agent | What it does |
-|---|---|
-| `explorer` | trace code before changing it; read-only |
-| `architect` | design + ADRs; no production code |
-| `implementer` | one issue end-to-end; no merges, no scope creep |
-| `bug-hunter` | failing regression test first, then minimum fix |
-| `reviewer` | pre-merge PR review; posts comments, never pushes |
-| `ci-devops` | hooks, workflows, compose, Dockerfiles — not app code |
-| `docs-writer` | README / CLAUDE.md / ADRs / followup in sync with code |
+| Agent | What it does | Proactive trigger |
+|---|---|---|
+| `explorer` | trace code before changing it; read-only | "how does X work", "trace X" |
+| `architect` | design + ADRs; no production code | new subsystem / external dep / protocol |
+| `implementer` | one issue end-to-end; no merges, no scope creep | "implement #N", "take on #N" |
+| `bug-hunter` | failing regression test first, then minimum fix | bug report with symptom |
+| `reviewer` | pre-merge PR review; posts comments, never pushes | **on PR open / before merge** |
+| `ci-devops` | hooks, workflows, compose, Dockerfiles — not app code | touching `.github/`, hooks, `deploy/` |
+| `docs-writer` | README / CLAUDE.md / ADRs / followup in sync with code | **after setup/convention PR merges** |
 
-Claude Code picks one automatically based on the task, or you can delegate explicitly with the `Task` tool.
+Explicit delegation — `Task(subagent_type="<name>", prompt="…")`. The main session handles user clarification, merge authorization, and cross-agent coordination; everything else goes through an agent. Full rules in [`CLAUDE.md`](CLAUDE.md) → "Agent ownership".
 
 ## Architecture at a glance
 

--- a/followup.md
+++ b/followup.md
@@ -4,15 +4,13 @@
 
 Branch `main`, in sync with `origin/main`. Phase 0 complete. Phase 1 issue #1 merged (`3dd6cf6`): User + TgLinkCode models + Alembic baseline with partial unique index for link-code activity.
 
-Quality-gate epic #11 complete:
-- #6 + #7: pre-commit (ruff, mypy, vue-tsc) + pre-push (pytest, vitest) — merged `970a4c0`.
-- #8: CI hardened with Postgres service, split steps, npm ci via lockfile — merged `970a4c0`.
-- #10: onboarding + quality-gate docs in README + CLAUDE.md — merged `970a4c0`.
-- #9: branch protection on `main` — applied via `gh api`, documented in CLAUDE.md.
+Quality-gate epic #11 complete (pre-commit + pre-push + hardened CI + branch protection — `970a4c0`, `b3c3e68`).
+
+Agent infrastructure landed: seven specialized subagents under `.claude/agents/` (#13, merged `010ba7a`) with proactive triggers and tool whitelists. This PR (#15) wires them into the issue-driven flow via `CLAUDE.md` "Agent ownership" + a delegate-vs-direct decision matrix, and adds a proactive-trigger column to the README table.
 
 ## Next
 
-1. **Phase 1 — issue #2**: `feat(auth): register/login/refresh/me + JWT dependency`. Argon2 + python-jose + opaque refresh tokens (hashed in DB), service layer in `app/services/auth_service.py`, routers in `app/api/auth.py` + `app/api/me.py`. ADR if the refresh-rotation approach deviates from "rotate on every refresh".
-2. **Phase 1 — issue #4**: auth test suite with the live Postgres CI service.
+1. **Phase 1 — issue #2**: `feat(auth): register/login/refresh/me + JWT dependency`. Delegate to the `implementer` agent via the `Task` tool once this integration PR (#15) lands. Argon2 + python-jose + opaque hashed refresh tokens in DB; rotate on every refresh. ADR for refresh-token storage/rotation strategy if it deviates from the ADR-0003 auth baseline (likely needs one — call `architect` first).
+2. **Phase 1 — issue #4**: auth test suite against the live Postgres CI service.
 3. **Phase 1 — issue #3**: frontend Login/Register/Profile + Pinia auth store, 401 → refresh interceptor.
-4. **Phase 1 — separate ticket**: Telegram link-code endpoint + profile UI button. Small, keep it out of #2 so that PR stays focused.
+4. **Phase 1 — separate ticket**: Telegram link-code endpoint + profile UI button. Intentionally out of #2 to keep that PR focused.


### PR DESCRIPTION
Closes #15. Follow-up to #13.

## Summary

Profiles existed under \`.claude/agents/\` but the flow didn't know how to use them. This PR makes the integration explicit.

\`CLAUDE.md\`:
- **Agent ownership** table — every stage of the flow (research → design → implement → bug → review → infra → docs) mapped to a named agent with a proactive trigger.
- **Delegate vs handle directly** decision matrix — the top-level session keeps user clarification, merge authorization, multi-agent coordination, and followup.md management; everything else is delegated.
- Explicit \`Task(subagent_type=...)\` invocation examples + the invariant that agent-produced PRs still pass the three-layer quality gate.

\`README.md\`:
- Agents table gets a "Proactive trigger" column so human readers see when each one wakes up.

\`followup.md\`:
- Status updated (agents wired). Next points back to Phase 1 #2 (auth endpoints) — now to be implemented via the \`implementer\` agent, with the \`architect\` called first if the refresh-token design needs an ADR beyond ADR-0003.

## Test plan

- [x] CLAUDE.md has "Agent ownership" section with table + decision matrix
- [x] README agents table includes proactive triggers
- [x] followup.md status + next updated
- [x] pre-commit green
- [x] pre-push green
- [x] CI green (expected)

## Out of scope

- PreToolUse hooks enforcing per-agent file-path boundaries — flagged in #13, deferred unless prompt discipline leaks.
- Webhook-triggered auto-dispatch of subagents on \`gh pr opened\` — would need infrastructure outside Claude Code itself.