### PR TITLE
docs: harden followup.md rule as hard gate (#18)

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -18,7 +18,10 @@ You are the **Implementer**. You take **one** issue end-to-end: branch, code, ve
 6. Run `pre-commit run --all-files` and `pre-commit run --hook-stage pre-push --all-files` before pushing.
 7. Commit with `type(scope): description (#N)` per `CLAUDE.md`. Prefer one commit; squash fixup-commits before pushing.
 8. Push. Verify CI green. Open PR with `Closes #N` in the body.
-9. Update `followup.md` and the corresponding checkbox in `tasks/todo.md` in the **same** PR.
+9. Update `followup.md` and the corresponding checkbox in `tasks/todo.md` in the **same** PR. This is a hard gate — the reviewer will block merge without it (see CLAUDE.md → "Hard gate").
+   - **Tense**: write `Status` as if this PR is **already merged** — describe the new reality on `main`, not a plan. Include the commit SHA of the PR once squash-merged (placeholder SHA pre-merge is OK; reviewer accepts it).
+   - **Concreteness**: `Next` must list **3+ priorities with issue numbers**. No "TBD", "polish", "various improvements". If nothing is queued, open the next issue first.
+   - **Replace, don't append**: rewrite the whole file. `git log` is the history; `followup.md` is a snapshot.
 
 ## MUST
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -31,6 +31,12 @@ You are the **Reviewer**. Your job is to catch issues before the merge button.
 
 - Compare the diff against the issue's acceptance criteria **first**, before code review. A PR that technically works but misses scope is a must-fix.
 - Check the ADR gate on every PR that introduces a new dependency, package, or protocol.
+- **Verify `followup.md` was updated in this PR** and that the content meets the hard gate from CLAUDE.md:
+  - `Status` is rewritten as if the PR is already merged (describes new reality, not a plan).
+  - `Next` lists 3+ concrete priorities with issue numbers — no placeholders like "TBD" or "various improvements".
+  - The file was **replaced**, not appended to.
+  - Missing, unchanged, or placeholder-filled `followup.md` = **must-fix**. Block merge.
+- Verify `tasks/todo.md` checkboxes are ticked for what this PR actually lands — not over-ticked (scope creep claim) and not under-ticked (memory loss).
 - Flag every comment with `file:line` so the author can jump to it.
 - End with a single verdict: `approve` / `approve-with-suggestions` / `changes-requested`.
 - Use `gh pr review` (not inline edits) — you are a reviewer, not a pusher.
@@ -52,6 +58,12 @@ You are the **Reviewer**. Your job is to catch issues before the merge button.
 ## Acceptance criteria check
 - [x] criterion 1
 - [ ] criterion 2 — missing because <reason>; must-fix
+
+## Cross-session memory check
+- [ ] `followup.md` updated in this PR
+- [ ] Status describes post-merge state (not "will do X")
+- [ ] Next has 3+ concrete priorities with issue numbers (no "TBD")
+- [ ] `tasks/todo.md` checkboxes match what this PR actually lands
 
 ## Review comments
 ### must-fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,12 +174,23 @@ Every non-trivial change starts from a GitHub issue. Issues, not chat, are the s
 
 ### Hard gate
 
-A PR that introduces a new subsystem or makes an architectural choice **must** include one of:
+Every PR that closes an issue **must**:
+
+1. **Update `followup.md`**.
+   - `Status` is rewritten as if the PR is **already merged** — describe the new reality, not a plan.
+   - `Next` lists **3+ concrete priorities with issue numbers**. No placeholders like "TBD", "various improvements", or "polish". If there's genuinely nothing queued, open the next issue first and then land the PR.
+   - Replace the whole file — do not append. History lives in `git log`; `followup.md` is a snapshot.
+
+2. **Tick the corresponding checkbox(es) in `tasks/todo.md`** for items this PR lands. Do not delete ticked items — they are the record of work done.
+
+A PR that introduces a new subsystem or makes an architectural choice **additionally must** include one of:
 - A new ADR under `docs/adr/NNNN-title.md` (sequential numbering, format: Status / Date / Context / Decision / Reasoning / Consequences), OR
 - An update to an existing ADR (mark superseded if replaced), OR
 - A corresponding checklist update in `tasks/todo.md` if the plan already covered it.
 
 "New subsystem" means: a new top-level `app/` package, a new external service dependency, a new auth/permission mechanism, a new protocol (WS event type, bot command family), a new storage backend. When in doubt — write the ADR.
+
+**Reviewer blocks on a missing or stale `followup.md` update** — `must-fix`, not a nit. Without this, cross-session memory decays and the next session starts with stale priorities.
 
 ### gh CLI cheatsheet
 

--- a/followup.md
+++ b/followup.md
@@ -2,24 +2,22 @@
 
 ## Status
 
-Branch `main` green through Phase 1 issue #2: auth endpoints
-(`POST /api/auth/{register,login,refresh}`, `GET /api/me`) + argon2
-password hashing + HS256 JWT access tokens + opaque rotating refresh
-tokens (ADR-0005) with transactional rotation and chain-revoke on
-replay. Migration `fcecc869fd60` adds `refresh_tokens`. Minimum-viable
-sanity tests cover happy paths and replay; full suite tracked in #4.
+Branch `main`, in sync with `origin/main`. Phase 0 + Phase 1 auth backend complete.
 
-Phase 0 + Phase 1 issue #1 (User + TgLinkCode models, migration
-`5130146827ca`) already merged. Quality-gate epic #11 (pre-commit +
-pre-push + hardened CI + branch protection) in place. Agent
-infrastructure (#13, #15) landed.
+Merged to `main`:
+- Phase 0 scaffold (backend + frontend + compose + CI) — `1ca2974`, `779ebe5`.
+- Quality-gate epic #11 (pre-commit, pre-push, hardened CI with Postgres service, branch protection) — `970a4c0`, `b3c3e68`.
+- Agent infrastructure: 7 subagent profiles in `.claude/agents/` (#13, merged `010ba7a`) + issue-driven integration rules in `CLAUDE.md` (#15, merged `eabf32a`).
+- Phase 1 issue #1: `User` + `TgLinkCode` models with partial unique index for active link codes — `3dd6cf6`.
+- Phase 1 issue #2: auth backend — `POST /api/auth/{register,login,refresh}`, `GET /api/me`, argon2 password hashing, HS256 JWT access tokens, opaque rotating refresh tokens (ADR-0005, migration `fcecc869fd60`) with transactional rotation and chain-revoke on replay — `ca30aaf`. Minimum-viable sanity tests (5 passing) cover register happy path, login returns pair, `/me` requires Bearer, refresh rotates + replay detection. Full auth test suite tracked in #4.
+
+ADRs in force: 0001 (api+bot split with shared services), 0002 (Redis pub/sub realtime bus), 0003 (Telegram linking via one-time code), 0004 (float position for task ordering), 0005 (opaque rotating refresh tokens).
+
+Reviewer caught three should-fixes on PR #17 before merge (TTL config/ADR mismatch, too-broad `BaseException`, chain-revoke predicate wording) — all addressed in the fixup commit. Establishes that the agent cascade architect → implementer → reviewer is working end-to-end.
 
 ## Next
 
-1. **Phase 1 — issue #3**: frontend Login/Register/Profile + Pinia auth
-   store + 401-refresh interceptor. Consumes the endpoints from #2.
-2. **Phase 1 — issue #4**: full auth test suite against the live
-   Postgres CI service — transactional-refresh concurrency, expiry
-   edges, 401-distinction, replay edges beyond the sanity tests.
-3. **Phase 1 — separate ticket**: Telegram link-code endpoint +
-   profile UI button. Intentionally out of #2.
+1. **Issue #18** — the PR you're looking at: harden the `followup.md` rule so future PRs can't silently leak cross-session memory. Promote followup update to hard-gate; reviewer must block on missing/stale Status or Next.
+2. **Phase 1 — issue #3**: frontend Login / Register / Profile views + Pinia auth store + 401→refresh interceptor. Consumes the endpoints from #2. Pre-commit + pre-push already gate the Vue side via `vue-tsc` and `vitest`.
+3. **Phase 1 — issue #4**: full auth test suite against the live Postgres CI service. Beyond the sanity tests: concurrent refresh races, token-expiry edges, user-not-found vs wrong-password timing parity, link-code redemption edge cases.
+4. **Phase 1 — separate ticket (to be opened)**: Telegram link-code endpoint (`POST /api/me/tg-link-code`) + web UI "Link Telegram" button. Intentionally kept out of #2 and #3 to keep their PRs focused.


### PR DESCRIPTION
Closes #18.

## Summary

\`followup.md\` is the cross-session memory anchor — the \"Status / Next\" file that keeps the next session from starting cold. A PR that silently skips updating it leaks context. This PR promotes the rule from convention to hard-gate.

## Changes

\`CLAUDE.md\` → Issue-driven workflow \"Hard gate\" section:
- Every issue-closing PR must update \`followup.md\` with post-merge-tense \`Status\` and 3+ concretely-issue-numbered \`Next\` items, whole-file replace.
- Every issue-closing PR must tick the corresponding \`tasks/todo.md\` checkbox.
- Reviewer blocks missing/stale updates as must-fix.

\`.claude/agents/reviewer.md\`:
- New MUST item: verify followup.md update in the diff, check tense + concreteness + replace-vs-append.
- Response format gains a \"Cross-session memory check\" section that forces the reviewer to name the verdict explicitly.
- Missing followup = must-fix; blocks approve.

\`.claude/agents/implementer.md\`:
- Step 9 gets tense + concreteness + replace rules so the implementer produces compliant followup on the first pass.

\`followup.md\`:
- Rewritten to the new standard as a demonstration — Status describes the post-#2-merge reality with commit SHAs, Next lists four concretely-numbered priorities (#18 / #3 / #4 / TG link-code).

## Test plan

- [x] CLAUDE.md hard-gate section covers followup + tasks/todo.md
- [x] reviewer.md has MUST + response-format section for followup check
- [x] implementer.md has tense/concreteness/replace rules
- [x] followup.md in this PR demonstrates the rule
- [x] pre-commit green
- [x] pre-push green
- [x] CI green (pending)

## Out of scope

- Automated pre-commit check diffing \`followup.md\` against the parent commit. Prompt-level + reviewer discipline first; if it leaks in practice, open a follow-up with a hook.